### PR TITLE
feature: 프론트엔드 연동 API

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/DailyPriceController.java
+++ b/backend/src/main/java/com/example/backend/controller/DailyPriceController.java
@@ -15,14 +15,26 @@ public class DailyPriceController {
 
     private final DailyPriceService dailyPriceService;
 
-    @GetMapping("/{stockCode}")
-    public ResponseEntity<List<DailyPriceDTO>> getDailyPrices(@PathVariable String stockCode) {
+    @PostMapping("/{stockCode}")
+    public ResponseEntity<List<DailyPriceDTO>> postDailyPrices(@PathVariable String stockCode) {
         try {
-            List<DailyPriceDTO> dailyPrices = dailyPriceService.getDailyPrices(stockCode);
+            List<DailyPriceDTO> dailyPrices = dailyPriceService.postDailyPrice(stockCode);
             dailyPriceService.saveList(dailyPrices);
             return ResponseEntity.ok(dailyPrices);
         } catch (Exception e) {
             return ResponseEntity.status(500).body(null);
         }
     }
+
+    @GetMapping("/{stockCode}")
+    public ResponseEntity<List<DailyPriceDTO>> getDailyPrices(@PathVariable String stockCode) {
+        try {
+            List<DailyPriceDTO> dailyPrices = dailyPriceService.getDailyPrice(stockCode);
+            return ResponseEntity.ok(dailyPrices);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(null);
+        }
+    }
+
+
 }

--- a/backend/src/main/java/com/example/backend/controller/DailyPriceController.java
+++ b/backend/src/main/java/com/example/backend/controller/DailyPriceController.java
@@ -36,5 +36,4 @@ public class DailyPriceController {
         }
     }
 
-
 }

--- a/backend/src/main/java/com/example/backend/controller/StockController.java
+++ b/backend/src/main/java/com/example/backend/controller/StockController.java
@@ -1,0 +1,24 @@
+package com.example.backend.controller;
+
+import com.example.backend.service.StockService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/stocks")
+public class StockController {
+
+    private final StockService stockService;
+
+    public StockController(StockService stockService) {
+        this.stockService = stockService;
+    }
+
+    @GetMapping("/search/{stockName}")
+    public List<String> searchStock(@PathVariable String stockName) throws Exception {
+        List<String> lst = stockService.findWith(stockName);
+        return lst;
+    }
+
+}

--- a/backend/src/main/java/com/example/backend/entity/DailyStockPrice.java
+++ b/backend/src/main/java/com/example/backend/entity/DailyStockPrice.java
@@ -1,10 +1,12 @@
 package com.example.backend.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.Setter;
 
 @Entity
 @Setter
+@Getter
 @Table(name = "DAILY_STOCK_TB")
 public class DailyStockPrice {
 

--- a/backend/src/main/java/com/example/backend/repository/DailyStockPriceRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/DailyStockPriceRepository.java
@@ -3,6 +3,10 @@ package com.example.backend.repository;
 import com.example.backend.entity.DailyStockPrice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DailyStockPriceRepository extends JpaRepository<DailyStockPrice, Integer> {
     DailyStockPrice findByStockIdAndDate(String stockId, Integer date);
+
+    List<DailyStockPrice> findByStockId(String stockCode);
 }

--- a/backend/src/main/java/com/example/backend/repository/StockRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/StockRepository.java
@@ -2,16 +2,22 @@ package com.example.backend.repository;
 
 import com.example.backend.entity.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Integer> {
 
     // 특정 주식 ID로 조회
-    List<Stock> findByStockId(String stockId);
+    Optional<Stock> findByStockId(String stockId);
 
     // 특정 주식 이름으로 조회
     List<Stock> findByStockName(String stockName);
+
+    List<Stock> findByStockNameContaining(String stockName);
 }

--- a/backend/src/main/java/com/example/backend/service/DailyPriceService.java
+++ b/backend/src/main/java/com/example/backend/service/DailyPriceService.java
@@ -44,7 +44,7 @@ public class DailyPriceService {
         this.restTemplate = restTemplate;
     }
 
-    public List<DailyPriceDTO> getDailyPrices(String stockCode) throws Exception {
+    public List<DailyPriceDTO> postDailyPrice(String stockCode) throws Exception {
         String url = baseUrl + DAILY_PATH;
 
         // HTTP Header 설정
@@ -99,6 +99,7 @@ public class DailyPriceService {
 
         return priceList;
     }
+
     @Transactional
     public void saveList(List<DailyPriceDTO> dtoList) throws Exception {
 
@@ -125,4 +126,37 @@ public class DailyPriceService {
             }
         }
     }
+
+    public List<DailyPriceDTO> getDailyPrice(String stockCode) throws Exception {
+        List<DailyPriceDTO> dailyPriceList = getDailyPriceFromDB(stockCode);
+        return dailyPriceList;
+    }
+
+    @Transactional
+    public List<DailyPriceDTO> getDailyPriceFromDB(String stockCode) throws Exception {
+        List<DailyStockPrice> dailyPriceList = dailyStockPriceRepository.findByStockId(stockCode);
+
+        List<DailyPriceDTO> dailyPriceDTOList = new ArrayList<>();
+
+        for (DailyStockPrice dailyStockPrice : dailyPriceList) {
+            DailyPriceDTO dailyPriceDTO = new DailyPriceDTO();
+
+            // DailyStockPrice의 데이터를 DailyPriceDTO로 매핑
+            dailyPriceDTO.setStockId(dailyStockPrice.getStockId());
+            dailyPriceDTO.setDate(dailyStockPrice.getDate());
+            dailyPriceDTO.setHigh(dailyStockPrice.getHighPrice());
+            dailyPriceDTO.setLow(dailyStockPrice.getLowPrice());;
+            dailyPriceDTO.setOpen(dailyStockPrice.getOpeningPrice());
+            dailyPriceDTO.setClose(dailyStockPrice.getClosingPrice());
+            dailyPriceDTO.setVolume(dailyStockPrice.getCntgVol());
+            dailyPriceDTO.setChangeRate(dailyStockPrice.getFluctuationRateDaily());
+
+            // DTO를 리스트에 추가
+            dailyPriceDTOList.add(dailyPriceDTO);
+        }
+
+        return dailyPriceDTOList;
+
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/service/KisService.java
+++ b/backend/src/main/java/com/example/backend/service/KisService.java
@@ -121,7 +121,7 @@ public class KisService {
 
     @Scheduled(fixedRate = 10000)
     public void fetchVolumeRankPeriodically() {
-        System.out.println("Start!!!!");
+        //System.out.println("Start!!!!");
         getVolumeRank().subscribe(response -> {
             response.forEach(dto -> {
                 try {

--- a/backend/src/main/java/com/example/backend/service/KisService.java
+++ b/backend/src/main/java/com/example/backend/service/KisService.java
@@ -107,21 +107,9 @@ public class KisService {
 
     }
 
-//    @Scheduled(fixedRate = 10000) // 10초 마다 실행 (300,000 ms = 5분 -> 10,000ms = 10ch)
-//    public void fetchVolumeRankPeriodically() {
-//        // 5분마다 실행될 작업
-//        getVolumeRank().subscribe(response -> {
-//            // 응답 처리 로직 (예: 로그로 출력)
-//            System.out.println("Volume rank fetched: " + response);
-//        }, error -> {
-//            // 오류 처리 로직
-//            System.err.println("Error fetching volume rank: " + error.getMessage());
-//        });
-//    }
-
     @Scheduled(fixedRate = 10000)
     public void fetchVolumeRankPeriodically() {
-        //System.out.println("Start!!!!");
+
         getVolumeRank().subscribe(response -> {
             response.forEach(dto -> {
                 try {

--- a/backend/src/main/java/com/example/backend/service/StockService.java
+++ b/backend/src/main/java/com/example/backend/service/StockService.java
@@ -1,0 +1,33 @@
+package com.example.backend.service;
+
+import com.example.backend.entity.Stock;
+import com.example.backend.repository.StockRepository;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class StockService {
+
+
+    private final StockRepository stockRepository;
+
+    public StockService(StockRepository stockRepository) {
+        this.stockRepository = stockRepository;
+    }
+
+    @Transactional
+    public List<String> findWith(String stockName) throws Exception {
+        List<String> lst = new ArrayList<>();
+
+        List<Stock> stocks = stockRepository.findByStockNameContaining(stockName);
+        for (Stock stock : stocks) {
+            lst.add(stock.getStockId());
+        }
+        return lst;
+    }
+}


### PR DESCRIPTION
## Overview

- 검색 API
- 시세 조회 API 리팩토링
    
## Change Log
- 검색 API 로직
  - 실시간으로 가져오는 랭킹 데이터를 stock table에도 추가
    - stock table은 stock id와 stock name column 존재
  - 특정 단어가 stock table의 stock name에 존재하는 경우, 해당 stock id 반환
    - 반환된 stock id를 통해 프론트에서 POST, GET `/api/daily-price/005930`해 DB에 데이터 넣고 반환
    
- 시세 조회 API 리팩토링
  - POST
    - 한국투자증권 API에 stockId를 넣어 데이터 불러와 DB에 저장
  - GET
    - stockId에 해당하는 데이터를 DB로부터 반환   
    
## To Reviewer
- 자세한 내용은 노션 확인해주세요
  - https://dohk325.notion.site/f23d8cb703b54ad98c139c03712f2dec?pvs=4
- 검색 API
  - `http://localhost:8080/stocks/search/삼성`
- 시세 조회 API
  - `http://localhost:8080/api/daily-price/005930`

## Acceptance Criteria
- 데이터 저장 및 반환 성공
  - MySQL Workbench 
  - POSTMAN 
    
