### PR TITLE
feat: daily data GET할 때 stock name 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/DailyPriceController.java
+++ b/backend/src/main/java/com/example/backend/controller/DailyPriceController.java
@@ -1,6 +1,7 @@
 package com.example.backend.controller;
 
 import com.example.backend.dto.DailyPriceDTO;
+import com.example.backend.dto.DailyPriceStockNameDTO;
 import com.example.backend.service.DailyPriceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +28,9 @@ public class DailyPriceController {
     }
 
     @GetMapping("/{stockCode}")
-    public ResponseEntity<List<DailyPriceDTO>> getDailyPrices(@PathVariable String stockCode) {
+    public ResponseEntity<List<DailyPriceStockNameDTO>> getDailyPrices(@PathVariable String stockCode) {
         try {
-            List<DailyPriceDTO> dailyPrices = dailyPriceService.getDailyPrice(stockCode);
+            List<DailyPriceStockNameDTO> dailyPrices = dailyPriceService.getDailyPrice(stockCode);
             return ResponseEntity.ok(dailyPrices);
         } catch (Exception e) {
             return ResponseEntity.status(500).body(null);

--- a/backend/src/main/java/com/example/backend/dto/DailyPriceStockNameDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/DailyPriceStockNameDTO.java
@@ -1,0 +1,30 @@
+package com.example.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+public class DailyPriceStockNameDTO {
+    private String stockName;
+    private String stockId;
+
+    private Integer date;  // 거래 날짜
+
+    private Integer high;  // 고가
+
+    private Integer low;   // 저가
+
+    private Integer close; // 종가
+
+    private Integer open;  // 시가
+
+    private Integer changeRate; // 등락율
+
+    private Integer volume; // 일거래량
+}

--- a/backend/src/main/java/com/example/backend/entity/Stock.java
+++ b/backend/src/main/java/com/example/backend/entity/Stock.java
@@ -1,9 +1,11 @@
 package com.example.backend.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
 @Table(name = "STOCK_TB")
+@Getter
 public class Stock {
 
     @Id

--- a/backend/src/main/java/com/example/backend/service/KisService.java
+++ b/backend/src/main/java/com/example/backend/service/KisService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -123,4 +124,7 @@ public class KisService {
             System.err.println("Error fetching volume rank: " + error.getMessage());
         });
     }
+
+
+
 }


### PR DESCRIPTION
## Overview
- 프론트엔드에 필요한 데이터 전달
    
## Change Log
- `http://localhost:8080/api/daily-price/005930` 결과에 stock name 추가
    
## To Reviewer
- 노션 확인해주세요
  - daily stock tb 일별시세조회 
  - https://dohk325.notion.site/API-f23d8cb703b54ad98c139c03712f2dec?pvs=4

## Acceptance Criteria
- POSTMAN 결과
    
