### PR TITLE
feat: popular entity 수정, popular get api 생성

### DIFF
--- a/backend/src/main/java/com/example/backend/config/DataInitializer.java
+++ b/backend/src/main/java/com/example/backend/config/DataInitializer.java
@@ -15,7 +15,7 @@ public class DataInitializer implements CommandLineRunner {
     public void run(String... args) {
         for (int i = 1; i <= 30; i++) {
 
-            Popular popular = new Popular(i, String.valueOf(i));
+            Popular popular = new Popular(i, String.valueOf(i), String.valueOf(i), i);
 
             popularRepository.save(popular);
         }

--- a/backend/src/main/java/com/example/backend/controller/KisController.java
+++ b/backend/src/main/java/com/example/backend/controller/KisController.java
@@ -1,10 +1,12 @@
 package com.example.backend.controller;
 
+import com.example.backend.dto.PopularDTO;
 import com.example.backend.dto.RankingDTO;
 import com.example.backend.dto.ResponseOutputDTO;
 import com.example.backend.service.KisService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
@@ -26,6 +28,10 @@ public class KisController {
         this.kisTokenService = kisTokenService;
     }
 
+    @GetMapping("/api/get-popular/{stockId}")
+    public PopularDTO getPopular(@PathVariable String stockId) {
+        return kisService.getPopular(stockId);
+    }
 
     @GetMapping("/volume-rank")
     public Mono<List<ResponseOutputDTO>> getVolumeRank() {

--- a/backend/src/main/java/com/example/backend/dto/PopularDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/PopularDTO.java
@@ -1,6 +1,7 @@
 package com.example.backend.dto;
 
 import com.example.backend.entity.Popular;
+import jakarta.persistence.Column;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,9 +10,13 @@ import lombok.Setter;
 public class PopularDTO {
     private String stockId;
     private Integer ranking;
+    private String stockName;
+    private Integer acmlvol;
 
     public PopularDTO(Popular popular) {
         this.stockId = popular.getStockId();
         this.ranking = popular.getRanking();
+        this.stockName = popular.getStockName();
+        this.acmlvol = popular.getAcmlvol();
     }
 }

--- a/backend/src/main/java/com/example/backend/entity/Popular.java
+++ b/backend/src/main/java/com/example/backend/entity/Popular.java
@@ -21,9 +21,17 @@ public class Popular {
     @Column(name = "ranking")
     private Integer ranking;
 
+    @Column(name = "stock_name")
+    private String stockName;
+
+    @Column(name = "acmlvol")
+    private Integer acmlvol;
+
     // Getters and Setters
-    public Popular(Integer ranking, String stockId){
+    public Popular(Integer ranking, String stockId, String stockName, Integer acmlvol) {
         this.ranking = ranking;
         this.stockId = stockId;
+        this.stockName = stockName;
+        this.acmlvol = acmlvol;
     }
 }

--- a/backend/src/main/java/com/example/backend/repository/PopularRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/PopularRepository.java
@@ -13,8 +13,10 @@ public interface PopularRepository extends JpaRepository<Popular, Integer> {
 
     // ranking 값으로 stockId 변경
     @Modifying
-    @Query("UPDATE Popular p SET p.stockId = :stockId WHERE p.ranking = :ranking")
-    int updateStockIdByRanking(String stockId, Integer ranking);
+    @Query("UPDATE Popular p SET p.stockId = :stockId, p.stockName = :stockName, p.acmlvol = :acmlVol WHERE p.ranking = :ranking")
+    int updateStockByRanking(String stockId, Integer ranking, String stockName, Integer acmlVol);
 
     List<Popular> findByRankingBetween(Integer lower, Integer upper);
+
+    Popular findByStockId(String stockId);
 }

--- a/backend/src/main/java/com/example/backend/service/KafkaConsumerService.java
+++ b/backend/src/main/java/com/example/backend/service/KafkaConsumerService.java
@@ -118,9 +118,9 @@ public class KafkaConsumerService {
     }
 
     @Transactional
-    public void updateStockIdByRanking(String mkscShrnIscd, Integer dataRank) {
+    public void updateStockByRanking(String mkscShrnIscd, Integer dataRank, String stockName, String acmlVol) {
 
-        int updatedRows = popularRepository.updateStockIdByRanking(mkscShrnIscd, dataRank);
+        int updatedRows = popularRepository.updateStockByRanking(mkscShrnIscd, dataRank, stockName, Integer.valueOf(acmlVol));
         if (updatedRows == 0) {
             throw new RuntimeException("Failed to update stockId for ranking: " + dataRank);
         }
@@ -146,6 +146,8 @@ public class KafkaConsumerService {
             // Save to MySQL
             Integer dataRank = dto.getDataRank();
             String mkscShrnIscd = dto.getMkscShrnIscd();
+            String stockName = dto.getHtsKorIsnm();
+            String acmlVol = dto.getAcmlVol();
 
             //popular repository
             Optional<Popular> popular = popularRepository.findByRanking(dataRank);
@@ -153,7 +155,7 @@ public class KafkaConsumerService {
                 PopularDTO popularDto = new PopularDTO(popular.get());
 
                 if (!popularDto.getStockId().equals(mkscShrnIscd)) {
-                    updateStockIdByRanking(mkscShrnIscd, dataRank);
+                    updateStockByRanking(mkscShrnIscd, dataRank, stockName, acmlVol);
                 }
             }
 

--- a/backend/src/main/java/com/example/backend/service/KisService.java
+++ b/backend/src/main/java/com/example/backend/service/KisService.java
@@ -1,5 +1,6 @@
 package com.example.backend.service;
 
+import com.example.backend.dto.PopularDTO;
 import com.example.backend.dto.RankingDTO;
 import com.example.backend.entity.DailyStockPrice;
 import com.example.backend.entity.Popular;
@@ -191,5 +192,10 @@ public class KisService {
         return dataList;
     }
 
+    public PopularDTO getPopular(String stockId) {
+        Popular popular = popularRepository.findByStockId(stockId);
+        PopularDTO dto = new PopularDTO(popular);
+        return dto;
+    }
 
 }


### PR DESCRIPTION
## Overview

- 기존에는 프론트에서 여러 개의 API 사용
  - 10개의 랭킹 데이터의 stockId를 주는 API
  - 각 stockId로 daily db 데이터 추가하는 POST API
  - 위에서 post한 데이터를 GET하는 API
  
- 프론트에서 보여줄 때 위 API 과정에서 오류 발생
  - POST를 비동기적으로 처리하면 한국투자증권 API 초당 거래건수 초과 오류 발생
  - 순서대로 동기적으로 처리하면 렌더링한 후 10초 후 데이터가 나타남
    - API 초당 거래건수 초과를 해결하기 위해 딜레이 줬기 때문

- 따라서 실시간으로 popular db에 저장할 때 프론트에 필요한 데이터 모두 저장해 해결 

## Change Log
- popular entity 변경
  - stockName(주식 이름), acmlVol(누적 거래량) 추가 
  - 즉 실시간으로 카프카에서 popular 데이터 넣을 때 해당 데이터들도 추가 저장
- 렌더링할 때 마다 popular DB에서 데이터 가져오는 GET API 생성

## To Reviewer
- GET `api/get-popular/{stockId}`

- Popular DB에 ranking, ranking_id, acml_vol, stock_id, stock_name column 존재

- 결과는 노션 확인해주세요
  - https://dohk325.notion.site/MySQL-Kafka-2b905705acdf4a6d80b8bee35a63be31?pvs=4

