### PR TITLE
feat: Kafka DLT Logic & Slack Alarm

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/DLTController.java
+++ b/backend/src/main/java/com/example/backend/controller/DLTController.java
@@ -1,0 +1,22 @@
+package com.example.backend.controller;
+
+import com.example.backend.service.KafkaProducerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DLTController {
+
+    @Autowired
+    private KafkaProducerService kafkaProducerService;
+
+    // 메시지 전송 API (POST 요청)
+    @PostMapping("/api/send")
+    public String sendRDSMessage(@RequestParam String topic, @RequestBody String message) {
+        kafkaProducerService.sendMessage(topic, message);
+        return "Message sent to Kafka main-topic";
+    }
+}

--- a/backend/src/main/java/com/example/backend/service/DLTConsumerService.java
+++ b/backend/src/main/java/com/example/backend/service/DLTConsumerService.java
@@ -36,12 +36,4 @@ public class DLTConsumerService {
         slackNotificationService.sendMessageToSlack(message);
     }
 
-
-//    //realtime-data-*
-//    @KafkaListener(topics = "realtime-data-.*-dlt", groupId = "my-consumer-group")
-//    public void retryConsumeRedis(String message) throws JsonProcessingException {
-//        log.info("retryConsumeRedis message: {}", message);
-//    }
-
-
 }

--- a/backend/src/main/java/com/example/backend/service/DLTConsumerService.java
+++ b/backend/src/main/java/com/example/backend/service/DLTConsumerService.java
@@ -1,0 +1,47 @@
+package com.example.backend.service;
+
+import com.example.backend.dto.PopularDTO;
+import com.example.backend.dto.ResponseOutputDTO;
+import com.example.backend.entity.Popular;
+import com.example.backend.entity.Stock;
+import com.example.backend.repository.PopularRepository;
+import com.example.backend.repository.StockRepository;
+import com.example.backend.websocket.StockWebSocketHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class DLTConsumerService {
+    @Autowired
+    private SlackNotificationService slackNotificationService;
+
+    //volume-rank-topic-dlt
+    @KafkaListener(topics = "volume-rank-topic-dlt", groupId = "my-consumer-group")
+    public void retryConsumeRDS(String message) throws JsonProcessingException {
+        log.info("RetryConsumeRDS message: {}", message);
+        slackNotificationService.sendMessageToSlack(message);
+    }
+
+
+//    //realtime-data-*
+//    @KafkaListener(topics = "realtime-data-.*-dlt", groupId = "my-consumer-group")
+//    public void retryConsumeRedis(String message) throws JsonProcessingException {
+//        log.info("retryConsumeRedis message: {}", message);
+//    }
+
+
+}

--- a/backend/src/main/java/com/example/backend/service/KafkaConsumerService.java
+++ b/backend/src/main/java/com/example/backend/service/KafkaConsumerService.java
@@ -3,14 +3,25 @@ package com.example.backend.service;
 import com.example.backend.entity.Stock;
 import com.example.backend.repository.StockRepository;
 import com.example.backend.websocket.StockWebSocketHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -31,6 +42,9 @@ public class KafkaConsumerService {
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> redisTemplate;
     private final StockWebSocketHandler webSocketHandler;
+
+    @Autowired
+    private KafkaProducerService kafkaProducerService;
 
     @Autowired
     private StockRepository stockRepository;
@@ -80,7 +94,9 @@ public class KafkaConsumerService {
             webSocketHandler.broadcastMessage(jsonData);
 
         } catch (Exception e) {
-            log.error("Kafka 메시지 처리 중 오류: ", e);
+            log.error("[ERROR] Error processing message: " + e.getMessage());
+            log.info("[LOG] Send Message to dlt-redis-topic");
+            kafkaProducerService.sendMessage("dlt-redis-topic", message);
         }
     }
 
@@ -107,7 +123,7 @@ public class KafkaConsumerService {
             Map<String, String> latestDataMap = objectMapper.readValue(latestData, new TypeReference<Map<String, String>>() {});
             return stockData.equals(latestDataMap);
         } catch (Exception e) {
-            log.error("중복 데이터 확인 오류: ", e);
+            log.error("[ERROR] 중복 데이터 확인 오류: ", e);
             return false;
         }
     }
@@ -139,47 +155,56 @@ public class KafkaConsumerService {
             stockRepository.save(stock);
         } catch (DataIntegrityViolationException e) {
             // 중복인 경우 로그만 남기고 무시
-            log.warn("Duplicate stock entry ignored: {}", stock.getStockId());
+            log.info("[ERROR] Duplicate stock entry ignored: {}", stock.getStockId());
         }
     }
 
+    @RetryableTopic(
+            attempts = "3",  // 최대 3번 재시도
+            backoff = @Backoff(delay = 2000)  // 재시도 간격 2초
+    )
     @KafkaListener(topics = "volume-rank-topic", groupId = "volume-rank-consumer-group")
     @Transactional
-    public void consumeMessage(String message) {
-        try {
-            // Deserialize JSON to DTO
-            ResponseOutputDTO dto = objectMapper.readValue(message, ResponseOutputDTO.class);
-            // Save to MySQL
-            Integer dataRank = dto.getDataRank();
-            String mkscShrnIscd = dto.getMkscShrnIscd();
-            String stockName = dto.getHtsKorIsnm();
-            String acmlVol = dto.getAcmlVol();
+    public void consumeMessage(String message,@Header(name = "kafka_deliveryAttempt", required = false, defaultValue = "1") int attempt) throws JsonProcessingException {
+        log.info("[LOG] Processing message: {}", message);
 
-            //popular repository
-            Optional<Popular> popular = popularRepository.findByRanking(dataRank);
-            //log.info("popular: "+popular);
-            if (popular.isPresent()) {
-                //데이터가 존재하는 경우 업데이트
-                PopularDTO popularDto = new PopularDTO(popular.get());
+        // Deserialize JSON to DTO
+        ResponseOutputDTO dto = objectMapper.readValue(message, ResponseOutputDTO.class);
 
-                if (!popularDto.getStockId().equals(mkscShrnIscd)) {
-                    updateStockByRanking(mkscShrnIscd, dataRank, stockName, acmlVol);
-                }
-            } else {
-                //데이터가 존재하지 않는 경우 저장
-                log.info("[ERROR] Popular not found for ranking: {}", dataRank);
-                saveStockByRanking(mkscShrnIscd, dataRank, stockName, Integer.valueOf(acmlVol));
+        // 데이터
+        if (dto.getDataRank() == null ||
+                dto.getMkscShrnIscd() == null || dto.getMkscShrnIscd().isEmpty() ||
+                dto.getHtsKorIsnm() == null || dto.getHtsKorIsnm().isEmpty() ||
+                dto.getAcmlVol() == null || dto.getAcmlVol().isEmpty()) {
+            throw new IllegalArgumentException("[ERROR] 필수 필드 중 하나 이상이 비어 있음");
+        }
+
+        // Save to MySQL
+        Integer dataRank = dto.getDataRank();
+        String mkscShrnIscd = dto.getMkscShrnIscd();
+        String stockName = dto.getHtsKorIsnm();
+        String acmlVol = dto.getAcmlVol();
+
+        //popular repository
+        Optional<Popular> popular = popularRepository.findByRanking(dataRank);
+        //log.info("popular: "+popular);
+        if (popular.isPresent()) {
+            //데이터가 존재하는 경우 업데이트
+            PopularDTO popularDto = new PopularDTO(popular.get());
+
+            if (!popularDto.getStockId().equals(mkscShrnIscd)) {
+                updateStockByRanking(mkscShrnIscd, dataRank, stockName, acmlVol);
             }
+        } else {
+            //데이터가 존재하지 않는 경우 저장
+            log.info("[LOG] Popular not found for ranking: {}", dataRank);
+            saveStockByRanking(mkscShrnIscd, dataRank, stockName, Integer.valueOf(acmlVol));
+        }
 
-            //stock repository
-            Optional<Stock> stock = stockRepository.findByStockId(mkscShrnIscd);
-            if (stock.isEmpty()) {
-                saveStock(dto);
-            }
-
-            //System.out.println("Saved to MySQL. Time: " + LocalTime.now());
-        } catch (Exception e) {
-            System.err.println("[ERROR] Error processing message: " + e.getMessage());
+        //stock repository
+        Optional<Stock> stock = stockRepository.findByStockId(mkscShrnIscd);
+        if (stock.isEmpty()) {
+            saveStock(dto);
         }
     }
 }

--- a/backend/src/main/java/com/example/backend/service/SlackNotificationService.java
+++ b/backend/src/main/java/com/example/backend/service/SlackNotificationService.java
@@ -1,0 +1,43 @@
+package com.example.backend.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SlackNotificationService {
+    @Value("${slack.web-hook-url}")
+    private String slackWebhookUrl;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void sendMessageToSlack(String message) throws JsonProcessingException {
+
+        // JSON 데이터 생성
+        Map<String, String> payload = new HashMap<>();
+        payload.put("text", message);
+        String jsonPayload = objectMapper.writeValueAsString(payload);
+
+        // HTTP 헤더 설정
+        org.springframework.http.HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // HTTP 요청
+        HttpEntity<String> request = new HttpEntity<>(jsonPayload, headers);
+        restTemplate.postForEntity(slackWebhookUrl, request, String.class);
+
+        log.info("[LOG] Message sent to Slack");
+    }
+}


### PR DESCRIPTION
## Overview
- Kafka로 수신한 메세지 데이터 무결성 처리
- Redis 데이터는 실시간으로 데이터를 가져오기 때문에 데이터 무결성 처리 시 딜레이 발생 -> 실시간 서비스의 경우 불리
- 따라서 MySQL 데이터만 처리 
    
## Change Log
- Consumer에서 한 번만 처리 -> 정상적으로 처리되지 않은 경우 최대 3번 처리
- 3번 시도해도 처리되지 않은 데이터는 관리자가 직접 처리해야하므로 Slack 알림 전송
- API를 통해 Kafka에 데이터가 들어가므로 오류 데이터 처리를 확인하기 위해 새로운 Rest API 필요 
    
## To Reviewer
- DLT Controller에 오류 데이터 넣어 테스트
- application.properties 변경사항 존재
- 아래 노션 페이지 확인해주세요
  - https://www.notion.so/dohk325/2-DLQ-197e1d5493988030a41beb91ba122b9a?pvs=4

## Acceptance Criteria
- 백엔드 로그에 3번 Retry 출력
- Kafka consumer에 접근해 volume-rank-topic-dlt에 오류 데이터 삽입 확인
  - `bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic volume-rank-topic-dlt --from-beginning`
- Slack 알림 전송